### PR TITLE
client: make the code work

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,13 +11,26 @@
   "author": "Lucien Lee <lucien@lucienlee.cc>",
   "license": "MIT",
   "devDependencies": {
+    "@babel/core": "^7.4.5",
+    "@babel/plugin-transform-runtime": "^7.4.4",
     "parcel-bundler": "^1.12.3"
   },
   "dependencies": {
+    "@babel/runtime": "^7.4.5",
     "bootstrap": "^4.3.1",
     "jquery": "^3.4.1",
     "popper.js": "^1.15.0",
     "truffle-contract": "^4.0.20",
-    "web3": "^1.0.0-beta.55"
-  }
+    "web3": "1.0.0-beta.37"
+  },
+  "comment": "locking web3 version due to https://github.com/ethereum/web3.js/issues/2362",
+  "babel": {
+    "plugins": [
+      "@babel/plugin-transform-runtime"
+    ]
+  },
+  "browserslist": [
+    ">0.25%",
+    "not op_mini all"
+  ]
 }

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -1,4 +1,4 @@
-import Web3 from "Web3";
+import Web3 from "web3";
 import TruffleContract from "truffle-contract";
 
 import $ from "jquery";
@@ -7,6 +7,7 @@ import $ from "jquery";
 import TutorialTokenArtifact from "../contracts/MyToken.json";
 
 const App = {
+  web3: null,
   web3Provider: null,
   contracts: {},
 
@@ -18,24 +19,26 @@ const App = {
     if (window.ethereum) {
       try {
         App.web3Provider = web3.currentProvider;
-        web3 = new Web3(ethereum);
+        App.web3 = new Web3(ethereum);
         await ethereum.enable();
       } catch (e) {
         console.error(e);
-        $content.find("#error-message").text("Need to request account access.");
+        const $content = $($("#failed-alert").html());
+        $content.find("#error-message").text(e.message);
+        $content.appendTo("#alert-slot");
         return;
       }
     }
     // Initialize web3 and set the provider to the testRPC.
     else if (typeof web3 !== "undefined") {
       App.web3Provider = web3.currentProvider;
-      web3 = new Web3(web3.currentProvider);
+      App.web3 = new Web3(web3.currentProvider);
     } else {
       // set the provider you want from Web3.providers
       App.web3Provider = new Web3.providers.HttpProvider(
         "http://127.0.0.1:9545"
       );
-      web3 = new Web3(App.web3Provider);
+      App.web3 = new Web3(App.web3Provider);
     }
 
     return App.initContract();
@@ -67,9 +70,10 @@ const App = {
 
     console.log("Transfer " + amount + " MT to " + toAddress);
 
-    web3.eth.getAccounts(function(error, accounts) {
+    App.web3.eth.getAccounts(function(error, accounts) {
       if (error) {
         console.log(error);
+        return;
       }
 
       var account = accounts[0];
@@ -101,9 +105,10 @@ const App = {
   getBalances: function() {
     console.log("Getting balances...");
 
-    web3.eth.getAccounts(function(error, accounts) {
+    App.web3.eth.getAccounts(function(error, accounts) {
       if (error) {
         console.log(error);
+        return;
       }
 
       const account = accounts[0];


### PR DESCRIPTION
1. import "web3" instead of "Web3"
2. install `@babel/plugin-transform-runtime` to make the `initWeb3`
   async function`initWeb3` async function work
3. lock web3 version at 1.0.0-beta37 for https://github.com/ethereum/web3.js/issues/2362